### PR TITLE
Remove left-over ign-cmake2 for Garden

### DIFF
--- a/ign-msgs9.yaml
+++ b/ign-msgs9.yaml
@@ -1,9 +1,5 @@
 ---
 repositories:
-  ign-cmake2:
-    type: git
-    url: https://github.com/ignitionrobotics/ign-cmake
-    version: ign-cmake2
   ign-cmake:
     type: git
     url: https://github.com/ignitionrobotics/ign-cmake

--- a/ign-transport12.yaml
+++ b/ign-transport12.yaml
@@ -1,9 +1,5 @@
 ---
 repositories:
-  ign-cmake2:
-    type: git
-    url: https://github.com/ignitionrobotics/ign-cmake
-    version: ign-cmake2
   ign-cmake:
     type: git
     url: https://github.com/ignitionrobotics/ign-cmake


### PR DESCRIPTION
Left-over from the transition when we had both `cmake2` and `cmake3`