### PR TITLE
gz-tools2 depend on gz-cmake3

### DIFF
--- a/ign-tools2.yaml
+++ b/ign-tools2.yaml
@@ -1,5 +1,9 @@
 ---
 repositories:
+  ign-cmake:
+    type: git
+    url: https://github.com/gazebosim/gz-cmake
+    version: main
   ign-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools


### PR DESCRIPTION
* Goes with https://github.com/gazebosim/gz-tools/pull/96

Test Windows CI: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_tools-pr-win&build=103)](https://build.osrfoundation.org/job/ign_tools-pr-win/103/)