### PR TITLE
Remove ign- symlinks for post-Garden versions

### DIFF
--- a/ign-cmake4.yaml
+++ b/ign-cmake4.yaml
@@ -1,1 +1,0 @@
-gz-cmake4.yaml

--- a/ign-tools3.yaml
+++ b/ign-tools3.yaml
@@ -1,1 +1,0 @@
-gz-tools3.yaml


### PR DESCRIPTION
A bit of a race condition between 

* #115 
* #116 

And 

* #117 

We don't need symlinks after Garden, Gazebo-H+ are `gz`-native!