### PR TITLE
Create a new workflow based off of conda-forge

### DIFF
--- a/.github/ci/colcon_defaults.yaml
+++ b/.github/ci/colcon_defaults.yaml
@@ -1,0 +1,33 @@
+{
+  "build": {
+    "merge-install": true,
+    "event-handlers": [
+      "console_package_list+",
+      "console_cohesion+",
+      "console_start_end-",
+      "actions_start_end+",
+    ],
+    "cmake-args": [
+      "--no-warn-unused-cli",
+      "-GNinja",
+      "-DCMAKE_BUILD_TYPE=Release",
+      "-DCMAKE_C_COMPILER_LAUNCHER=buildcache",
+      "-DCMAKE_CXX_COMPILER_LAUNCHER=buildcache",
+      "-DBUILD_DOCS:BOOL=OFF",
+      "-DSKIP_optix:BOOL=ON",
+      "-DSKIP_SWIG:BOOL=ON",
+      "-DSKIP_PYBIND11:BOOL=ON",
+      "-DUSE_GZ_RECOMMENDED_MSVC_CACHING:BOOL=ON",
+    ],
+    "executor": "sequential",
+  },
+  "test": {
+    "merge-install": true,
+    "event-handlers": [
+      "console_cohesion+",
+      "console_start_end-",
+      "actions_start_end+",
+    ],
+    "executor": "sequential",
+  }
+}

--- a/.github/ci/environment.win-64.yaml
+++ b/.github/ci/environment.win-64.yaml
@@ -1,0 +1,8 @@
+name: gazebo-ws
+
+channels:
+  - conda-forge
+
+dependencies:
+  - dlfcn-win32
+  - vs2019_win-64 

--- a/.github/ci/environment.yaml
+++ b/.github/ci/environment.yaml
@@ -1,0 +1,34 @@
+name: base
+
+channels:
+  - conda-forge
+
+dependencies:
+  - anaconda-client
+  - cmake
+  - colcon-common-extensions
+  - compilers
+  - cppzmq
+  - curl
+  - eigen
+  - ffmpeg
+  - freeimage
+  - gdal
+  - git
+  - glib
+  - gts
+  - jsoncpp
+  - libzip
+  - make
+  - ninja
+  - ogre
+  - pkg-config
+  - protobuf
+  - pybind11
+  - qt
+  - ruby
+  - tinyxml
+  - tinyxml2
+  - urdfdom
+  - vcstool
+  - zeromq

--- a/.github/ci/environment.yaml
+++ b/.github/ci/environment.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pkg-config
   - protobuf
   - pybind11
-  - qt
+  - qt-main
   - ruby
   - tinyxml
   - tinyxml2

--- a/.github/workflows/build_garden.yaml
+++ b/.github/workflows/build_garden.yaml
@@ -118,15 +118,15 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        echo "CC=x86_64-conda-linux-gnu-gcc" >> $GITHUB_ENV
-        echo "CXX=x86_64-conda-linux-gnu-g++" >> $GITHUB_ENV
+        echo "BUILDCACHE_CC=x86_64-conda-linux-gnu-gcc" >> $GITHUB_ENV
+        echo "BUILDCACHE_CXX=x86_64-conda-linux-gnu-g++" >> $GITHUB_ENV
 
     - name: Export compiler variables [macOS]
       if: contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
-        echo "CC=x86_64-apple-darwin13.4.0-clang" >> $GITHUB_ENV
-        echo "CXX=x86_64-apple-darwin13.4.0-clang++" >> $GITHUB_ENV
+        echo "BUILDCACHE_CC=x86_64-apple-darwin13.4.0-clang" >> $GITHUB_ENV
+        echo "BUILDCACHE_CXX=x86_64-apple-darwin13.4.0-clang++" >> $GITHUB_ENV
 
     - name: Checkout Workspace [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
@@ -141,6 +141,8 @@ jobs:
       if: (contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')) && success()
       shell: bash -l {0}
       run: |
+        export CC=${{ env.BUILDCACHE_CC }}
+        export CXX=${{ env.BUILDCACHE_CXX }}
         cd workspace
         echo "::group::Workspace Branches"
         vcs branch
@@ -151,6 +153,8 @@ jobs:
       if: (contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')) && success()
       shell: bash -l {0}
       run: |
+        export CC=${{ env.BUILDCACHE_CC }}
+        export CXX=${{ env.BUILDCACHE_CXX }}
         cd workspace
         colcon test ${{ env.COLCON_TEST_ARGS }}
 

--- a/.github/workflows/build_garden.yaml
+++ b/.github/workflows/build_garden.yaml
@@ -36,8 +36,8 @@ jobs:
     env:
       # Workspace file to use for the build
       VCS_WORKSPACE_FILE: collection-garden.yaml
-      COLCON_BUILD_ARGS: "--packages-up-to gz-common5" 
-      COLCON_TEST_ARGS: "--packages-up-to gz-common5" 
+      COLCON_BUILD_ARGS: "--packages-up-to gz-rendering6" 
+      COLCON_TEST_ARGS: "--packages-up-to gz-rendering6" 
 
       # Things that control build
       COLCON_DEFAULTS_FILE: ${{ github.workspace }}/.github/ci/colcon_defaults.yaml

--- a/.github/workflows/build_garden.yaml
+++ b/.github/workflows/build_garden.yaml
@@ -42,8 +42,8 @@ jobs:
       # Things that control build
       COLCON_DEFAULTS_FILE: ${{ github.workspace }}/.github/ci/colcon_defaults.yaml
       BUILDCACHE_MAX_CACHE_SIZE: 2000000000                      # optional: Need a bigger cache?
-      BUILDCACHE_LOG_FILE: ${{ matrix.label }}.buildcache.log    # optional: include log output
-      BUILDCACHE_DEBUG: 2                                        # optional: debug level, less is more
+      # BUILDCACHE_LOG_FILE: ${{ matrix.label }}.buildcache.log    # optional: include log output
+      # BUILDCACHE_DEBUG: 2                                        # optional: debug level, less is more
       BUILDCACHE_DIRECT_MODE: true                               # optional: Allow direct caching
     steps:
     - uses: actions/checkout@v2
@@ -68,8 +68,8 @@ jobs:
 
     - uses: mikehardy/buildcache-action@v1
       with:
-        cache_key: ${{ matrix.label }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
-        upload_buildcache_log: 'true' # optional: 100% cache misses? Find out why
+        cache_key: ${{ matrix.label }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}
+        upload_buildcache_log: 'false' # optional: 100% cache misses? Find out why
         zero_buildcache_stats: 'true' # optional: lifetime vs per-run stats?
 
     - name: Dependencies

--- a/.github/workflows/build_garden.yaml
+++ b/.github/workflows/build_garden.yaml
@@ -36,8 +36,8 @@ jobs:
     env:
       # Workspace file to use for the build
       VCS_WORKSPACE_FILE: collection-garden.yaml
-      COLCON_BUILD_ARGS: "--packages-up-to gz-common5" 
-      COLCON_TEST_ARGS: "--packages-up-to gz-common5" 
+      COLCON_BUILD_ARGS: "--packages-up-to sdformat13" 
+      COLCON_TEST_ARGS: "--packages-up-to sdformat13" 
 
       # Things that control build
       COLCON_DEFAULTS_FILE: ${{ github.workspace }}/.github/ci/colcon_defaults.yaml
@@ -157,6 +157,7 @@ jobs:
         export CXX=${{ env.BUILDCACHE_CXX }}
         cd workspace
         colcon test ${{ env.COLCON_TEST_ARGS }}
+        colcon test-result
 
     - name: Checkout Workspace [Windows]
       if: contains(matrix.os, 'windows')
@@ -180,3 +181,4 @@ jobs:
       run: |
         cd workspace
         colcon test ${{ env.COLCON_TEST_ARGS }}
+        colcon test-result

--- a/.github/workflows/build_garden.yaml
+++ b/.github/workflows/build_garden.yaml
@@ -69,7 +69,7 @@ jobs:
     - uses: mikehardy/buildcache-action@v1
       with:
         cache_key: ${{ matrix.label }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
-        upload_buildcache_log: 'false' # optional: 100% cache misses? Find out why
+        upload_buildcache_log: 'true' # optional: 100% cache misses? Find out why
         zero_buildcache_stats: 'true' # optional: lifetime vs per-run stats?
 
     - name: Dependencies
@@ -168,8 +168,6 @@ jobs:
       shell: cmd /C call {0}
       run: |
         cd workspace
-        set
-        where cl.exe
         colcon build ${{ env.COLCON_BUILD_ARGS }}
 
     - name: Test Workspace [Windows]

--- a/.github/workflows/build_garden.yaml
+++ b/.github/workflows/build_garden.yaml
@@ -1,0 +1,180 @@
+name: C++ CI Workflow with conda-forge dependencies
+
+on:
+  push:
+    branches:
+      - master 
+  pull_request:
+    paths:
+      - collection-garden.yaml
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *' 
+
+env:
+  CACHE_NUMBER: 0
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-64
+            conda_envs: /usr/share/miniconda/envs/gazebo-ws
+          - os: macos-latest
+            label: macos-64 
+            conda_envs: /usr/local/miniconda/envs/gazebo-ws
+          - os: windows-2019
+            label: win-64
+            conda_envs: C:\Miniconda\envs\gazebo-ws
+      fail-fast: false
+
+    name: '[${{ matrix.label }}@conda]'
+    runs-on: ${{ matrix.os }}
+    env:
+      # Workspace file to use for the build
+      VCS_WORKSPACE_FILE: collection-garden.yaml
+      COLCON_BUILD_ARGS: "--packages-up-to gz-common5" 
+      COLCON_TEST_ARGS: "--packages-up-to gz-common5" 
+
+      # Things that control build
+      COLCON_DEFAULTS_FILE: ${{ github.workspace }}/.github/ci/colcon_defaults.yaml
+      BUILDCACHE_MAX_CACHE_SIZE: 2000000000                      # optional: Need a bigger cache?
+      BUILDCACHE_LOG_FILE: ${{ matrix.label }}.buildcache.log    # optional: include log output
+      BUILDCACHE_DEBUG: 2                                        # optional: debug level, less is more
+      BUILDCACHE_DIRECT_MODE: true                               # optional: Allow direct caching
+    steps:
+    - uses: actions/checkout@v2
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        mamba-version: "*"
+        channels: conda-forge
+        channel-priority: true
+        activate-environment: gazebo-ws
+
+    - name: Get Date
+      id: get-date
+      run: echo "::set-output name=today::$(/bin/date -u '+%Y%m%d')"
+      shell: bash
+
+    - name: Cache conda
+      uses: actions/cache@v2
+      with:
+        path: ${{ matrix.conda_envs }}
+        key: ${{ runner.os }}-conda-${{ hashFiles('.github/ci/environment*.yaml') }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}
+      id: cache
+
+    - uses: mikehardy/buildcache-action@v1
+      with:
+        cache_key: ${{ matrix.label }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        upload_buildcache_log: 'false' # optional: 100% cache misses? Find out why
+        zero_buildcache_stats: 'true' # optional: lifetime vs per-run stats?
+
+    - name: Dependencies
+      run: |
+        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
+        conda config --remove channels defaults
+        mamba env update -n gazebo-ws -f .github/ci/environment.yaml
+      if: steps.cache.outputs.cache-hit != 'true'
+
+    - name: Windows-only Dependencies [Windows]
+      run: |
+        mamba env update -n gazebo-ws -f .github/ci/environment.win-64.yaml
+      if: contains(matrix.os, 'windows') && steps.cache.outputs.cache-hit != 'true'
+
+    - name: Colcon dependencies [Linux and macOS]
+      shell: bash -l {0}
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      run: |
+        echo "::group::Install colcon extensions"
+        # Make output prettier for github
+        python -m pip install --upgrade --force https://github.com/mjcarroll/colcon-github-actions/archive/refs/heads/master.zip
+        echo "::endgroup::"
+
+        echo "::group::List installed colcon extensions"
+        # Debug output
+        colcon extensions
+        echo "::endgroup::"
+
+    - name: Colcon dependencies [Windows]
+      shell: cmd /C call {0}
+      if: contains(matrix.os, 'windows')
+      run: |
+        echo "::group::Install colcon extensions"
+        # Make output prettier for github
+        python -m pip install --upgrade --force https://github.com/mjcarroll/colcon-github-actions/archive/refs/heads/master.zip
+        # Windows needs the newest colcon-cmake until the next release
+        python -m pip install --upgrade --force https://github.com/colcon/colcon-cmake/archive/refs/heads/master.zip
+        echo "::endgroup::"
+
+        echo "::group::List installed colcon extensions"
+        # Debug output
+        colcon extensions
+        echo "::endgroup::"
+
+    - name: Export compiler variables [Linux]
+      if: contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        echo "CC=x86_64-conda-linux-gnu-gcc" >> $GITHUB_ENV
+        echo "CXX=x86_64-conda-linux-gnu-g++" >> $GITHUB_ENV
+
+    - name: Export compiler variables [macOS]
+      if: contains(matrix.os, 'macos')
+      shell: bash -l {0}
+      run: |
+        echo "CC=x86_64-apple-darwin13.4.0-clang" >> $GITHUB_ENV
+        echo "CXX=x86_64-apple-darwin13.4.0-clang++" >> $GITHUB_ENV
+
+    - name: Checkout Workspace [Linux&macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
+        mkdir -p workspace/src
+        echo "::group::vcs import"
+        vcs import --input ${{ env.VCS_WORKSPACE_FILE }} --shallow workspace/src
+        echo "::endgroup::"
+
+    - name: Build Workspace [Linux&macOS]
+      if: (contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')) && success()
+      shell: bash -l {0}
+      run: |
+        cd workspace
+        echo "::group::Workspace Branches"
+        vcs branch
+        echo "::endgroup::"
+        colcon build ${{ env.COLCON_BUILD_ARGS }}
+
+    - name: Test Workspace [Linux&macOS]
+      if: (contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')) && success()
+      shell: bash -l {0}
+      run: |
+        cd workspace
+        colcon test ${{ env.COLCON_TEST_ARGS }}
+
+    - name: Checkout Workspace [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: cmd /C call {0}
+      run: |
+        mkdir workspace\src
+        echo "::group::vcs import"
+        vcs import --input ${{ env.VCS_WORKSPACE_FILE }} --shallow workspace\src
+        echo "::endgroup::"
+
+    - name: Build Workspace [Windows]
+      if: contains(matrix.os, 'windows') && success()
+      shell: cmd /C call {0}
+      run: |
+        cd workspace
+        set
+        where cl.exe
+        colcon build ${{ env.COLCON_BUILD_ARGS }}
+
+    - name: Test Workspace [Windows]
+      if: contains(matrix.os, 'windows') && success()
+      shell: cmd /C call {0}
+      run: |
+        cd workspace
+        colcon test ${{ env.COLCON_TEST_ARGS }}

--- a/.github/workflows/build_garden.yaml
+++ b/.github/workflows/build_garden.yaml
@@ -36,8 +36,8 @@ jobs:
     env:
       # Workspace file to use for the build
       VCS_WORKSPACE_FILE: collection-garden.yaml
-      COLCON_BUILD_ARGS: "--packages-up-to gz-rendering6" 
-      COLCON_TEST_ARGS: "--packages-up-to gz-rendering6" 
+      COLCON_BUILD_ARGS: "--packages-up-to gz-common5" 
+      COLCON_TEST_ARGS: "--packages-up-to gz-common5" 
 
       # Things that control build
       COLCON_DEFAULTS_FILE: ${{ github.workspace }}/.github/ci/colcon_defaults.yaml

--- a/collection-garden.yaml
+++ b/collection-garden.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake3
+    version: mjcarroll/windows
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
@@ -27,7 +27,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math7
+    version: mjcarroll/examples_from_cmake
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs


### PR DESCRIPTION
This workflow allows for building a whole gazebo workspace in one shot from a distribution yaml file.


Important Elements:

* Uses `conda-forge` for dependencies on macOS, Linux, and Windows
  * Dependencies are specified in [.github/ci/environment.yaml]
  * Windows specific dependencies are stored in [.github/ci/environment.win-64.yaml]
  * Conda environments are cached.  As currently specified, the cache is refreshed at 2am UTC
 * Uses `Ninja` as the builder
  * `ninja` generated files have better support for [buildcache](https://github.com/mbitsnbites/buildcache) on all supported platforms
  * Compiler cache is stored between runs via the [buildcache-action](https://github.com/mikehardy/buildcache-action)

Currently, it is only  set up to run against modifications to `collection-garden`, but could be modified to include more via environment variables in the workflow:

```
      VCS_WORKSPACE_FILE: collection-garden.yaml
      COLCON_BUILD_ARGS: "" 
      COLCON_TEST_ARGS: "" 
 ```
 
 Also makes use of https://github.com/mjcarroll/colcon-github-actions to try to group colcon output for multiple packages.