### PR TITLE
Use gz-sim7 in gz-launch7 by now

### DIFF
--- a/gz-launch7.yaml
+++ b/gz-launch7.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim7
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui


### PR DESCRIPTION
Should fix https://github.com/gazebosim/gz-launch/pull/195

Current `main` is [gz-launch7](https://github.com/gazebosim/gz-launch/blob/main/CMakeLists.txt#L6) which [uses gz-sim7](https://github.com/gazebosim/gz-launch/blob/main/CMakeLists.txt#L91-L92).

Tested: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_launch-ci-win&build=74)](https://build.osrfoundation.org/job/ign_launch-ci-win/74/)