### PR TITLE
Bump gui8 to depend on rendering8

### DIFF
--- a/gz-gui8.yaml
+++ b/gz-gui8.yaml
@@ -27,7 +27,7 @@ repositories:
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering7
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

https://github.com/gazebo-tooling/release-tools/issues/853