### PR TITLE
Bump sim8 to depend on gui8, sensors8, and rendering8 (main branch)

### DIFF
--- a/gz-sim8.yaml
+++ b/gz-sim8.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: gz-gui7
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
@@ -39,11 +39,11 @@ repositories:
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering7
+    version: main
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
-    version: gz-sensors7
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

https://github.com/gazebo-tooling/release-tools/issues/853