### PR TITLE
Bump launch7 to depend on sim8, gui8, sensors8, and rendering8 (main branch)

### DIFF
--- a/gz-launch7.yaml
+++ b/gz-launch7.yaml
@@ -15,11 +15,11 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: gz-sim7
+    version: main
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: gz-gui7
+    version: main
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
@@ -43,11 +43,11 @@ repositories:
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: gz-rendering7
+    version: main
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
-    version: gz-sensors7
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

https://github.com/gazebo-tooling/release-tools/issues/853