### PR TITLE
Bumps for msgs10

### DIFF
--- a/gz-fuel-tools9.yaml
+++ b/gz-fuel-tools9.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs9
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools

--- a/gz-gui8.yaml
+++ b/gz-gui8.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs9
+    version: main
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-launch7.yaml
+++ b/gz-launch7.yaml
@@ -31,7 +31,7 @@ repositories:
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs9
+    version: main
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics

--- a/gz-sensors8.yaml
+++ b/gz-sensors8.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs9
+    version: main
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-sim8.yaml
+++ b/gz-sim8.yaml
@@ -27,7 +27,7 @@ repositories:
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs9
+    version: main
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics

--- a/gz-transport13.yaml
+++ b/gz-transport13.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs9
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools


### PR DESCRIPTION
We probably need some other bumps:
```
gazebodistro on  jrivero/msgs10 [!] underwent 14s❯ grep -R msgs9 *
collection-garden.yaml:    version: gz-msgs9
gz-fuel-tools8.yaml:    version: gz-msgs9
gz-fuel-tools9.yaml:    version: gz-msgs9
gz-gui7.yaml:    version: gz-msgs9
gz-gui8.yaml:    version: gz-msgs9
gz-launch6.yaml:    version: gz-msgs9
gz-launch7.yaml:    version: gz-msgs9
gz-msgs9.yaml:    version: gz-msgs9
gz-sensors7.yaml:    version: gz-msgs9
gz-sensors8.yaml:    version: gz-msgs9
gz-sim7.yaml:    version: gz-msgs9
gz-sim8.yaml:    version: gz-msgs9
gz-transport12.yaml:    version: gz-msgs9
```
The ones duplicated in the list I assume.