### PR TITLE
Use main branch for fuel tools in harmonic

### DIFF
--- a/collection-harmonic.yaml
+++ b/collection-harmonic.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools
-    version: gz-fuel-tools8
+    version: main
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

Now that msgs and transport are bumped in harmonic, we need to bump version for all packages to depend on them. 