### PR TITLE
Use gz-physics7 and gz-gui8 stable branches in harmonic

### DIFF
--- a/collection-harmonic.yaml
+++ b/collection-harmonic.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: main
+    version: gz-gui8
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
@@ -35,7 +35,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics7
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-gui8.yaml
+++ b/gz-gui8.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: main
+    version: gz-gui8
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
@@ -27,7 +27,7 @@ repositories:
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: main
+    version: gz-rendering8
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools

--- a/gz-launch7.yaml
+++ b/gz-launch7.yaml
@@ -35,7 +35,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: gz-physics8
+    version: gz-physics7
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-launch7.yaml
+++ b/gz-launch7.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: main
+    version: gz-gui8
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
@@ -35,7 +35,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics8
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
@@ -43,7 +43,7 @@ repositories:
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: main
+    version: gz-rendering8
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
@@ -63,4 +63,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf14

--- a/gz-physics7.yaml
+++ b/gz-physics7.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics7
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-sim8.yaml
+++ b/gz-sim8.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: main
+    version: gz-gui8
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
@@ -31,7 +31,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics7
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin


### PR DESCRIPTION
In addition, I also updated the files to use gz-rendering8 and sdf14 stable branches that were missed in previous PRs