### PR TITLE
Use gz-sim8 and gz-launch7 stable branches in harmonic

### DIFF
--- a/collection-harmonic.yaml
+++ b/collection-harmonic.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim8
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
@@ -23,7 +23,7 @@ repositories:
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
-    version: main
+    version: gz-launch7
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-launch7.yaml
+++ b/gz-launch7.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim8
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
@@ -23,7 +23,7 @@ repositories:
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
-    version: main
+    version: gz-launch7
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-physics7.yaml
+++ b/gz-physics7.yaml
@@ -27,4 +27,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf14

--- a/gz-sensors8.yaml
+++ b/gz-sensors8.yaml
@@ -23,7 +23,7 @@ repositories:
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: main
+    version: gz-rendering8
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
@@ -43,4 +43,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf14

--- a/gz-sim8.yaml
+++ b/gz-sim8.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim8
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
@@ -39,7 +39,7 @@ repositories:
   gz-rendering:
     type: git
     url: https://github.com/gazebosim/gz-rendering
-    version: main
+    version: gz-rendering8
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
@@ -59,4 +59,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: main
+    version: sdf14


### PR DESCRIPTION
Merge when we are ready for pre-release

Found and update more instances in harmonic yaml files that still use `main`

