### PR TITLE
gz-utils3: use gz-cmake4 in ionic

### DIFF
--- a/gz-utils3.yaml
+++ b/gz-utils3.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake3
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils


### PR DESCRIPTION
See https://github.com/gazebo-tooling/release-tools/issues/1027