### PR TITLE
Add gz-tools to gz-plugin

### DIFF
--- a/gz-plugin2.yaml
+++ b/gz-plugin2.yaml
@@ -8,6 +8,10 @@ repositories:
     type: git
     url: https://github.com/gazebosim/gz-plugin
     version: gz-plugin2
+  gz-tools:
+    type: git
+    url: https://github.com/gazebosim/gz-tools
+    version: gz-tools2
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils

--- a/gz-plugin3.yaml
+++ b/gz-plugin3.yaml
@@ -8,6 +8,10 @@ repositories:
     type: git
     url: https://github.com/gazebosim/gz-plugin
     version: main
+  gz-tools:
+    type: git
+    url: https://github.com/gazebosim/gz-tools
+    version: gz-tools2
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils


### PR DESCRIPTION
gz-plugin depends on gz-tools (see https://github.com/gazebosim/gz-plugin/blob/c45ddf2033cd5191aff9239b9710dd07c5e9b24e/.github/ci/packages.apt#L2), but they were missing from gazebodistro.