### PR TITLE
gz-sensors8: test sdf branch scpeters/fix_windows_linking_without_tests

### DIFF
--- a/gz-sensors8.yaml
+++ b/gz-sensors8.yaml
@@ -43,4 +43,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat
-    version: sdf14
+    version: scpeters/fix_windows_linking_without_tests


### PR DESCRIPTION
this is a change made to support testing gz-sensors8 with https://github.com/gazebosim/sdformat/pull/1468

I opened a draft pull request so that this change will be preserved after the branch is deleted for documentation purposes, but it is not intended to be merged.