### PR TITLE
Ionic: use stable branch for gz-physics8

### DIFF
--- a/collection-ionic.yaml
+++ b/collection-ionic.yaml
@@ -35,7 +35,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics8
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-launch8.yaml
+++ b/gz-launch8.yaml
@@ -35,7 +35,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics8
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-physics8.yaml
+++ b/gz-physics8.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics8
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-sim9.yaml
+++ b/gz-sim9.yaml
@@ -31,7 +31,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics8
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092