### PR TITLE
Ionic: use stable branch for gz-common6

### DIFF
--- a/collection-ionic.yaml
+++ b/collection-ionic.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools

--- a/gz-common6.yaml
+++ b/gz-common6.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-fuel-tools10.yaml
+++ b/gz-fuel-tools10.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools

--- a/gz-gui9.yaml
+++ b/gz-gui9.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui

--- a/gz-launch8.yaml
+++ b/gz-launch8.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools

--- a/gz-physics8.yaml
+++ b/gz-physics8.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-rendering9.yaml
+++ b/gz-rendering9.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-sensors9.yaml
+++ b/gz-sensors9.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-sim9.yaml
+++ b/gz-sim9.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common6
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092