### PR TITLE
Ionic: use stable branch for gz-launch8

### DIFF
--- a/collection-ionic.yaml
+++ b/collection-ionic.yaml
@@ -23,7 +23,7 @@ repositories:
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
-    version: main
+    version: gz-launch8
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-launch8.yaml
+++ b/gz-launch8.yaml
@@ -23,7 +23,7 @@ repositories:
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch
-    version: main
+    version: gz-launch8
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092