### PR TITLE
Ionic: use stable branch for gz-sim9

### DIFF
--- a/collection-ionic.yaml
+++ b/collection-ionic.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim9
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui

--- a/gz-launch8.yaml
+++ b/gz-launch8.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim9
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui

--- a/gz-sim9.yaml
+++ b/gz-sim9.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim9
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092

Draft - requires the gz-sim9 branch to be created first