### PR TITLE
gz-gui10: Bump gz-transport and others in jetty

### DIFF
--- a/gz-gui10.yaml
+++ b/gz-gui10.yaml
@@ -35,7 +35,7 @@ repositories:
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport14
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1292.