### PR TITLE
gz-sensors10: Bump gz-transport and others in jetty

### DIFF
--- a/gz-sensors10.yaml
+++ b/gz-sensors10.yaml
@@ -31,7 +31,7 @@ repositories:
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport14
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1292.