### PR TITLE
gz-sim10: Bump gz-transport and others in jetty

### DIFF
--- a/gz-gui10.yaml
+++ b/gz-gui10.yaml
@@ -35,7 +35,7 @@ repositories:
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport14
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils

--- a/gz-sensors10.yaml
+++ b/gz-sensors10.yaml
@@ -31,7 +31,7 @@ repositories:
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport14
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -43,7 +43,7 @@ repositories:
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
-    version: gz-sensors9
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
@@ -51,7 +51,7 @@ repositories:
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport14
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1292.