### PR TITLE
gz-jetty: Bump gz-transport and others in jetty

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -47,7 +47,7 @@ repositories:
   gz-sensors:
     type: git
     url: https://github.com/gazebosim/gz-sensors
-    version: gz-sensors9
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
@@ -55,7 +55,7 @@ repositories:
   gz-transport:
     type: git
     url: https://github.com/gazebosim/gz-transport
-    version: gz-transport14
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1292.