### PR TITLE
gz-utils4: Bump gz-cmake and others in jetty

### DIFF
--- a/gz-utils4.yaml
+++ b/gz-utils4.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake4
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1309.