### PR TITLE
gz-math9: Bump gz-cmake and others in jetty

### DIFF
--- a/gz-math9.yaml
+++ b/gz-math9.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake4
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
@@ -11,4 +11,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils3
+    version: main


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1309.