### PR TITLE
Use 24.04, python 3.12 in lint.yaml workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,8 +2,8 @@ name: Validate gazebodistro
 on: [push, pull_request]
 
 jobs:
-  nosetests:
-    name: Nosetests
+  pytest:
+    name: PyTest
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -22,11 +22,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install PyYAML argparse
-        pip install nose coverage
+        pip install pytest pytest-cov
         pip install unidiff
         pip install PyGithub
-    - name: Run Nose Tests
-      run: nosetests -s
+    - name: Run PyTest
+      run: pytest -v
   yamllint:
     name: Yaml Linting
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 jobs:
   nosetests:
     name: Nosetests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -29,10 +29,10 @@ jobs:
       run: nosetests -s
   yamllint:
     name: Yaml Linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
The 20.04 runners have already been disabled, so upgrade to 24.04 and a newer python version.