### PR TITLE
gz-plugin4: Bump gz-cmake and others in jetty

### DIFF
--- a/gz-plugin4.yaml
+++ b/gz-plugin4.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake4
+    version: main
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin
@@ -15,4 +15,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils3
+    version: main


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1309.