### PR TITLE
sdformat16: Bump gz-cmake and others in jetty

### DIFF
--- a/sdformat16.yaml
+++ b/sdformat16.yaml
@@ -3,11 +3,11 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake4
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math8
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
@@ -15,7 +15,7 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils3
+    version: main
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1309.