### PR TITLE
gz-common7: Bump gz-cmake and others in jetty

### DIFF
--- a/gz-common7.yaml
+++ b/gz-common7.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake4
+    version: main
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
@@ -11,8 +11,8 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math8
+    version: main
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils3
+    version: main


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1309.