### PR TITLE
gz-transport15: Bump gz-cmake and others in jetty

### DIFF
--- a/gz-transport15.yaml
+++ b/gz-transport15.yaml
@@ -3,15 +3,15 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake4
+    version: main
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: gz-math8
+    version: main
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs
-    version: gz-msgs11
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools
@@ -23,4 +23,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: gz-utils3
+    version: main


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1309.