### PR TITLE
gz-tools3: use gz-cmake main branch

### DIFF
--- a/gz-tools3.yaml
+++ b/gz-tools3.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: gz-cmake3
+    version: main
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools


### PR DESCRIPTION
Needed by https://github.com/gazebosim/gz-tools/pull/157.