### PR TITLE
gz-jetty: Use stable branch for gz-cmake5

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-cmake5.yaml
+++ b/gz-cmake5.yaml
@@ -3,4 +3,4 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5

--- a/gz-common7.yaml
+++ b/gz-common7.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-fuel-tools11.yaml
+++ b/gz-fuel-tools11.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-gui10.yaml
+++ b/gz-gui10.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-math9.yaml
+++ b/gz-math9.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-msgs12.yaml
+++ b/gz-msgs12.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-physics9.yaml
+++ b/gz-physics9.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-plugin4.yaml
+++ b/gz-plugin4.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-rendering10.yaml
+++ b/gz-rendering10.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-sensors10.yaml
+++ b/gz-sensors10.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common

--- a/gz-tools3.yaml
+++ b/gz-tools3.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools

--- a/gz-transport15.yaml
+++ b/gz-transport15.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-utils4.yaml
+++ b/gz-utils4.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils

--- a/sdformat16.yaml
+++ b/sdformat16.yaml
@@ -3,7 +3,7 @@ repositories:
   gz-cmake:
     type: git
     url: https://github.com/gazebosim/gz-cmake
-    version: main
+    version: gz-cmake5
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/19