### PR TITLE
gz-jetty: Use stable branch for gz-utils4

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -59,7 +59,7 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat

--- a/gz-common7.yaml
+++ b/gz-common7.yaml
@@ -15,4 +15,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/gz-fuel-tools11.yaml
+++ b/gz-fuel-tools11.yaml
@@ -27,4 +27,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/gz-gui10.yaml
+++ b/gz-gui10.yaml
@@ -39,4 +39,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -59,7 +59,7 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat

--- a/gz-math9.yaml
+++ b/gz-math9.yaml
@@ -11,4 +11,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/gz-msgs12.yaml
+++ b/gz-msgs12.yaml
@@ -19,4 +19,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/gz-physics9.yaml
+++ b/gz-physics9.yaml
@@ -23,7 +23,7 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat

--- a/gz-plugin4.yaml
+++ b/gz-plugin4.yaml
@@ -15,4 +15,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/gz-rendering10.yaml
+++ b/gz-rendering10.yaml
@@ -23,4 +23,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/gz-sensors10.yaml
+++ b/gz-sensors10.yaml
@@ -39,7 +39,7 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -55,7 +55,7 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat

--- a/gz-transport15.yaml
+++ b/gz-transport15.yaml
@@ -23,4 +23,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/gz-utils4.yaml
+++ b/gz-utils4.yaml
@@ -7,4 +7,4 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4

--- a/sdformat16.yaml
+++ b/sdformat16.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils
-    version: main
+    version: gz-utils4
   sdformat:
     type: git
     url: https://github.com/gazebosim/sdformat


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/21