### PR TITLE
gz-jetty: Use stable branch for gz-common7

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools

--- a/gz-common7.yaml
+++ b/gz-common7.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-fuel-tools11.yaml
+++ b/gz-fuel-tools11.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools

--- a/gz-gui10.yaml
+++ b/gz-gui10.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools

--- a/gz-physics9.yaml
+++ b/gz-physics9.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-rendering10.yaml
+++ b/gz-rendering10.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-sensors10.yaml
+++ b/gz-sensors10.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-common:
     type: git
     url: https://github.com/gazebosim/gz-common
-    version: main
+    version: gz-common7
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/pull/1370