### PR TITLE
Use stable branch gz-math9 in jetty packages

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -27,7 +27,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/gz-common7.yaml
+++ b/gz-common7.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils

--- a/gz-fuel-tools11.yaml
+++ b/gz-fuel-tools11.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/gz-gui10.yaml
+++ b/gz-gui10.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -27,7 +27,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/gz-math9.yaml
+++ b/gz-math9.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-utils:
     type: git
     url: https://github.com/gazebosim/gz-utils

--- a/gz-msgs12.yaml
+++ b/gz-msgs12.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/gz-physics9.yaml
+++ b/gz-physics9.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics

--- a/gz-rendering10.yaml
+++ b/gz-rendering10.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-sensors10.yaml
+++ b/gz-sensors10.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -23,7 +23,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/gz-transport15.yaml
+++ b/gz-transport15.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-msgs:
     type: git
     url: https://github.com/gazebosim/gz-msgs

--- a/sdformat16.yaml
+++ b/sdformat16.yaml
@@ -7,7 +7,7 @@ repositories:
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math
-    version: main
+    version: gz-math9
   gz-tools:
     type: git
     url: https://github.com/gazebosim/gz-tools


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/22.