### PR TITLE
gz-jetty: Use stable branch for gz-gui10

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: main
+    version: gz-gui10
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch

--- a/gz-gui10.yaml
+++ b/gz-gui10.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: main
+    version: gz-gui10
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: main
+    version: gz-gui10
   gz-launch:
     type: git
     url: https://github.com/gazebosim/gz-launch

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -19,7 +19,7 @@ repositories:
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui
-    version: main
+    version: gz-gui10
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/32