### PR TITLE
Jetty: use stable branch gz-physics9

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -35,7 +35,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics9
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -35,7 +35,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics9
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-physics9.yaml
+++ b/gz-physics9.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics9
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -31,7 +31,7 @@ repositories:
   gz-physics:
     type: git
     url: https://github.com/gazebosim/gz-physics
-    version: main
+    version: gz-physics9
   gz-plugin:
     type: git
     url: https://github.com/gazebosim/gz-plugin


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/29.