### PR TITLE
Use stable branch for gz-fuel-tools11

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools
-    version: main
+    version: gz-fuel-tools11
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim

--- a/gz-fuel-tools11.yaml
+++ b/gz-fuel-tools11.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools
-    version: main
+    version: gz-fuel-tools11
   gz-math:
     type: git
     url: https://github.com/gazebosim/gz-math

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools
-    version: main
+    version: gz-fuel-tools11
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -11,7 +11,7 @@ repositories:
   gz-fuel-tools:
     type: git
     url: https://github.com/gazebosim/gz-fuel-tools
-    version: main
+    version: gz-fuel-tools11
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/18