### PR TITLE
gz-jetty: Use stable branch for gz-sim10

### DIFF
--- a/collection-jetty.yaml
+++ b/collection-jetty.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim10
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui

--- a/gz-launch9.yaml
+++ b/gz-launch9.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim10
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui

--- a/gz-sim10.yaml
+++ b/gz-sim10.yaml
@@ -15,7 +15,7 @@ repositories:
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim
-    version: main
+    version: gz-sim10
   gz-gui:
     type: git
     url: https://github.com/gazebosim/gz-gui


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/33